### PR TITLE
update readme for code generation and fix commutator language

### DIFF
--- a/Scripts/symbolic_hermitians/README.md
+++ b/Scripts/symbolic_hermitians/README.md
@@ -5,42 +5,19 @@ expresses a symbolic Hermitian matrix in terms of its
 independent real-valued Real and Imaginary components.
 
 This class also provides functions for calculating an
-anticommutator scaled by I and generating code to implement this.
+commutator scaled by I and generating code to implement this.
 
-## Using HermitianUtils
+For a self-contained demonstration, see the Jupyter notebook
+`Symbolic-Hermitian-Commutator.ipynb`.
 
-The python script `IAntiCommutator.py` gives an example
-of how to use the `HermitianMatrix` class to calculate `C=i*[A,B]`.
+# Using HermitianUtils to generate Emu code
 
-The script generalizes to any desired matrix sizes and
-determines symbol names with runtime arguments.
+We generate all the computational kernels for Emu using the HermitianUtils
+python module in the `generate_code.py` script.
 
-The only required runtime argument is an integer matrix size.
+The generated source files are placed in `Emu/Source/generated_files` and are
+inserted into the Emu source code using compile-time `#include` statements.
 
-To see all optional runtime arguments:
-
-```
-$ python3 IAntiCommutator.py -h
-```
-
-## Generating code with Particle data indexing
-
-To generate sample code with indexing into real Particle data:
-
-```
-$ python3 IAntiCommutator.py 2 -o code.cpp -a "p.rdata(PIdx::H{}{}_{})" -b "p.rdata(PIdx::f{}{}_{})" -c "p.rdata(PIdx::dfdt{}{}_{})"
-```
-
-And the file `code.cpp` will contain:
-
-```
-{
-p.rdata(PIdx::dfdt00_Re) = -2*p.rdata(PIdx::H01_Im)*p.rdata(PIdx::f01_Re) + 2*p.rdata(PIdx::H01_Re)*p.rdata(PIdx::f01_Im);
-
-p.rdata(PIdx::dfdt01_Re) = -p.rdata(PIdx::H00_Re)*p.rdata(PIdx::f01_Im) + p.rdata(PIdx::H01_Im)*p.rdata(PIdx::f00_Re) - p.rdata(PIdx::H01_Im)*p.rdata(PIdx::f11_Re) + p.rdata(PIdx::H11_Re)*p.rdata(PIdx::f01_Im);
-
-p.rdata(PIdx::dfdt01_Im) = p.rdata(PIdx::H00_Re)*p.rdata(PIdx::f01_Re) - p.rdata(PIdx::H01_Re)*p.rdata(PIdx::f00_Re) + p.rdata(PIdx::H01_Re)*p.rdata(PIdx::f11_Re) - p.rdata(PIdx::H11_Re)*p.rdata(PIdx::f01_Re);
-
-p.rdata(PIdx::dfdt11_Re) = 2*p.rdata(PIdx::H01_Im)*p.rdata(PIdx::f01_Re) - 2*p.rdata(PIdx::H01_Re)*p.rdata(PIdx::f01_Im);
-}
-```
+To see options for `generate_code.py`, pass the `-h` option. You do not need to
+run this script manually, when building Emu, use the `make generate
+NUM_FLAVORS=N` command to generate these source files.

--- a/Scripts/symbolic_hermitians/Symbolic-Hermitian-Commutator.ipynb
+++ b/Scripts/symbolic_hermitians/Symbolic-Hermitian-Commutator.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Symbolic Hermitian Anticommutator"
+    "# Symbolic Hermitian Commutator"
    ]
   },
   {
@@ -113,7 +113,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Calculate anticommutator $[H,f] = H \\cdot f - f \\cdot H$"
+    "Calculate commutator $[H,f] = H \\cdot f - f \\cdot H$"
    ]
   },
   {
@@ -122,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "AC = H*F - F*H"
+    "Commutator = H*F - F*H"
    ]
   },
   {
@@ -138,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dFdt = sympy.I * AC"
+    "dFdt = sympy.I * Commutator"
    ]
   },
   {
@@ -263,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This updates the readme in the code generation subdirectory to remove references to a now nonexistent python script.

We now introduce the `generate_code.py` script instead.

Also fixes the matrix commutator language (I had accidentally called `[A,B] = AB - BA` an anticommutator in the sample notebook).