### PR TITLE
Added 3 flavor functionality for the sample_inputs test simulations

### DIFF
--- a/Source/FlavoredNeutrinoContainerInit.cpp
+++ b/Source/FlavoredNeutrinoContainerInit.cpp
@@ -248,7 +248,7 @@ InitParticles(const TestParams* parms)
 		  // set all particles to start in electron state (and anti-state)
 		  // Set N to be small enough that self-interaction is not important
 		  // Set all particle momenta to be such that one oscillation wavelength is 1cm
-		  AMREX_ASSERT(NUM_FLAVORS==2);
+		  AMREX_ASSERT(NUM_FLAVORS==3 or NUM_FLAVORS==2);
 
 		  // Set particle flavor
 		  p.rdata(PIdx::N) = 1.0;
@@ -261,6 +261,19 @@ InitParticles(const TestParams* parms)
 		  p.rdata(PIdx::f01_Rebar) = 0.0;
 		  p.rdata(PIdx::f01_Imbar) = 0.0;
 		  p.rdata(PIdx::f11_Rebar) = 0.0;
+
+#if (NUM_FLAVORS==3)
+		  p.rdata(PIdx::f22_Re)    = 0.0;
+		  p.rdata(PIdx::f22_Rebar) = 0.0;
+		  p.rdata(PIdx::f02_Re)    = 0.0;
+		  p.rdata(PIdx::f02_Im)    = 0.0;
+		  p.rdata(PIdx::f12_Re)    = 0.0;
+		  p.rdata(PIdx::f12_Im)    = 0.0;
+		  p.rdata(PIdx::f02_Rebar) = 0.0;
+		  p.rdata(PIdx::f02_Imbar) = 0.0;
+		  p.rdata(PIdx::f12_Rebar) = 0.0;
+		  p.rdata(PIdx::f12_Imbar) = 0.0;
+#endif
 
 		  // set momentum so that a vacuum oscillation wavelength occurs over a distance of 1cm
 		  // Set particle velocity to c in a random direction
@@ -275,7 +288,7 @@ InitParticles(const TestParams* parms)
 		// BIPOLAR OSCILLATION TEST //
 		//==========================//
 		else if(parms->simulation_type==1){
-		  AMREX_ASSERT(NUM_FLAVORS==2);
+		  AMREX_ASSERT(NUM_FLAVORS==3 or NUM_FLAVORS==2);
 		  
 		  // Set particle flavor
 		  p.rdata(PIdx::f00_Re)    = 1.0;
@@ -286,6 +299,19 @@ InitParticles(const TestParams* parms)
 		  p.rdata(PIdx::f01_Rebar) = 0.0;
 		  p.rdata(PIdx::f01_Imbar) = 0.0;
 		  p.rdata(PIdx::f11_Rebar) = 0.0;
+
+#if (NUM_FLAVORS==3)
+		  p.rdata(PIdx::f22_Re)    = 0.0;
+		  p.rdata(PIdx::f22_Rebar) = 0.0;
+		  p.rdata(PIdx::f02_Re)    = 0.0;
+		  p.rdata(PIdx::f02_Im)    = 0.0;
+		  p.rdata(PIdx::f12_Re)    = 0.0;
+		  p.rdata(PIdx::f12_Im)    = 0.0;
+		  p.rdata(PIdx::f02_Rebar) = 0.0;
+		  p.rdata(PIdx::f02_Imbar) = 0.0;
+		  p.rdata(PIdx::f12_Rebar) = 0.0;
+		  p.rdata(PIdx::f12_Imbar) = 0.0;
+#endif
 
 		  // set energy to 50 MeV to match Richers+(2019)
 		  p.rdata(PIdx::pupt) = 50. * 1e6*CGSUnitsConst::eV;
@@ -307,7 +333,7 @@ InitParticles(const TestParams* parms)
 		// 2-BEAM FAST FLAVOR TEST//
 		//========================//
 		else if(parms->simulation_type==2){
-		  AMREX_ASSERT(NUM_FLAVORS==2);
+		  AMREX_ASSERT(NUM_FLAVORS==3 or NUM_FLAVORS==2);
 		  
 		  // Set particle flavor
 		  p.rdata(PIdx::f00_Re)    = 1.0;
@@ -318,6 +344,19 @@ InitParticles(const TestParams* parms)
 		  p.rdata(PIdx::f01_Rebar) = 0.0;
 		  p.rdata(PIdx::f01_Imbar) = 0.0;
 		  p.rdata(PIdx::f11_Rebar) = 0.0;
+
+#if (NUM_FLAVORS==3)
+		  p.rdata(PIdx::f22_Re)    = 0.0;
+		  p.rdata(PIdx::f22_Rebar) = 0.0;
+		  p.rdata(PIdx::f02_Re)    = 0.0;
+		  p.rdata(PIdx::f02_Im)    = 0.0;
+		  p.rdata(PIdx::f12_Re)    = 0.0;
+		  p.rdata(PIdx::f12_Im)    = 0.0;
+		  p.rdata(PIdx::f02_Rebar) = 0.0;
+		  p.rdata(PIdx::f02_Imbar) = 0.0;
+		  p.rdata(PIdx::f12_Rebar) = 0.0;
+		  p.rdata(PIdx::f12_Imbar) = 0.0;
+#endif
 
 		  // set energy to 50 MeV to match Richers+(2019)
 		  p.rdata(PIdx::pupt) = 50. * 1e6*CGSUnitsConst::eV;
@@ -340,7 +379,7 @@ InitParticles(const TestParams* parms)
 		// 3- k!=0 BEAM FAST FLAVOR TEST //
 		//===============================//
 		else if(parms->simulation_type==3){
-		  AMREX_ASSERT(NUM_FLAVORS==2);
+		  AMREX_ASSERT(NUM_FLAVORS==3 or NUM_FLAVORS==2);
 
 		  // perturbation parameters
 		  Real lambda = domain_length_z/(Real)parms->st3_wavelength_fraction_of_domain;
@@ -355,6 +394,20 @@ InitParticles(const TestParams* parms)
 		  p.rdata(PIdx::f01_Rebar) = parms->st3_amplitude*sin(k*p.pos(2));
 		  p.rdata(PIdx::f01_Imbar) = 0.0;
 		  p.rdata(PIdx::f11_Rebar) = 0.0;
+
+#if (NUM_FLAVORS==3) 
+		  //just perturbing the electron-muon flavor state, other terms can stay = 0.0 for simplicity
+		  p.rdata(PIdx::f22_Re)    = 0.0;
+		  p.rdata(PIdx::f22_Rebar) = 0.0;
+		  p.rdata(PIdx::f02_Re)    = 0.0; 
+		  p.rdata(PIdx::f02_Im)    = 0.0; 
+		  p.rdata(PIdx::f12_Re)    = 0.0;
+		  p.rdata(PIdx::f12_Im)    = 0.0;
+		  p.rdata(PIdx::f02_Rebar) = 0.0; 
+		  p.rdata(PIdx::f02_Imbar) = 0.0; 
+		  p.rdata(PIdx::f12_Rebar) = 0.0;
+		  p.rdata(PIdx::f12_Imbar) = 0.0;
+#endif
 
 		  // set energy to 50 MeV to match Richers+(2019)
 		  p.rdata(PIdx::pupt) = 50. * 1e6*CGSUnitsConst::eV;

--- a/sample_inputs/inputs_bipolar_test
+++ b/sample_inputs/inputs_bipolar_test
@@ -55,7 +55,8 @@ mass1_eV = -0.008596511
 mass2_eV = 0
 
 # mass state 3 mass in eV [NO:sqrt(2.449e-3) IO:-sqrt(2.509e-3)]
-mass3_eV = 0.049487372
+#mass3_eV = 0.049487372
+mass3_eV = 0
 
 # 1-2 mixing angle in degrees [NO/IO:33.82]
 theta12_degrees = 33.82

--- a/sample_inputs/inputs_fast_flavor
+++ b/sample_inputs/inputs_fast_flavor
@@ -55,7 +55,8 @@ mass1_eV = -0.008596511
 mass2_eV = 0
 
 # mass state 3 mass in eV [NO:sqrt(2.449e-3) IO:-sqrt(2.509e-3)]
-mass3_eV = 0.049487372
+#mass3_eV = 0.049487372
+mass3_eV = 0
 
 # 1-2 mixing angle in degrees [NO/IO:33.82]
 theta12_degrees = 1e-6

--- a/sample_inputs/inputs_msw_test
+++ b/sample_inputs/inputs_msw_test
@@ -55,7 +55,8 @@ mass1_eV = -0.008596511
 mass2_eV = 0
 
 # mass state 3 mass in eV [NO:sqrt(2.449e-3) IO:-sqrt(2.509e-3)]
-mass3_eV = 0.049487372
+# mass3_eV = 0.049487372
+mass3_eV = 0
 
 # 1-2 mixing angle in degrees [NO/IO:33.82]
 theta12_degrees = 33.82


### PR DESCRIPTION
closes #54. Note: needed to set mass3_eV = 0 for these simulations to run.