### PR TITLE
Optimize timestep

### DIFF
--- a/Scripts/symbolic_hermitians/HermitianUtils.py
+++ b/Scripts/symbolic_hermitians/HermitianUtils.py
@@ -93,7 +93,9 @@ class HermitianMatrix(object):
         return self
 
     def conjugate(self):
-        self.H = Conjugate(self.H)
+        for i in range(self.size):
+            for j in range(i, self.size):
+                self.H[i,j] = conjugate(self.H[i,j])
         return self
     
     # return the length of the SU(n) vector

--- a/Scripts/symbolic_hermitians/HermitianUtils.py
+++ b/Scripts/symbolic_hermitians/HermitianUtils.py
@@ -97,7 +97,7 @@ class HermitianMatrix(object):
         return self
     
     # return the length of the SU(n) vector
-    def SU_vector_magnitude(self):
+    def SU_vector_magnitude2(self):
         # first get the sum of the square of the off-diagonal elements
         mag2 = 0
         for i in range(self.size):
@@ -115,7 +115,10 @@ class HermitianMatrix(object):
             basis_coefficient *= sympy.sqrt(2./(l*(l+1.)))
             mag2 += (basis_coefficient/2.)**2
 
-        return sympy.sqrt(mag2)
+        return mag2
+
+    def SU_vector_magnitude(self):
+        return sympy.sqrt(self.SU_vector_magnitude2())
     
     def trace(self):
         result = 0

--- a/Scripts/symbolic_hermitians/HermitianUtils.py
+++ b/Scripts/symbolic_hermitians/HermitianUtils.py
@@ -37,18 +37,41 @@ class HermitianMatrix(object):
         self.construct()
     
     def __mul__(self, other):
-        result = copy.deepcopy(other)
-        result.H = self.H * other.H
+        result = copy.deepcopy(self)
+        if isinstance(other, self.__class__):
+            result.H = self.H * other.H
+        else:
+            for i in range(self.size):
+                for j in range(self.size):
+                    result.H[i,j] *= other
+        return result
+
+    def __truediv__(self, other):
+        result = copy.deepcopy(self)
+        if isinstance(other, self.__class__):
+            result.H = self.H * other.H
+        else:
+            for i in range(self.size):
+                for j in range(self.size):
+                    result.H[i,j] /= other
         return result
 
     def __add__(self, other):
-        result = copy.deepcopy(other)
-        result.H = self.H + other.H
+        result = copy.deepcopy(self)
+        if isinstance(other, self.__class__):
+            result.H = self.H + other.H
+        else:
+            for i in range(self.size):
+                result.H[i,i] += other
         return result
 
     def __sub__(self, other):
-        result = copy.deepcopy(other)
-        result.H = self.H - other.H
+        result = copy.deepcopy(self)
+        if isinstance(other, self.__class__):
+            result.H = self.H - other.H
+        else:
+            for i in range(self.size):
+                result.H[i,i] -= other
         return result
 
     def construct(self):

--- a/Scripts/symbolic_hermitians/HermitianUtils.py
+++ b/Scripts/symbolic_hermitians/HermitianUtils.py
@@ -49,7 +49,7 @@ class HermitianMatrix(object):
     def __truediv__(self, other):
         result = copy.deepcopy(self)
         if isinstance(other, self.__class__):
-            result.H = self.H * other.H
+            raise ArithmeticError
         else:
             for i in range(self.size):
                 for j in range(self.size):
@@ -94,7 +94,7 @@ class HermitianMatrix(object):
 
     def conjugate(self):
         for i in range(self.size):
-            for j in range(i, self.size):
+            for j in range(self.size):
                 self.H[i,j] = conjugate(self.H[i,j])
         return self
     

--- a/Scripts/symbolic_hermitians/HermitianUtils.py
+++ b/Scripts/symbolic_hermitians/HermitianUtils.py
@@ -102,7 +102,8 @@ class HermitianMatrix(object):
         mag2 = 0
         for i in range(self.size):
             for j in range(i+1,self.size):
-                mag2 += self.H[i,j]*self.H[j,i]
+                re,im = self.H[i,j].as_real_imag()
+                mag2 += re**2 + im**2
 
         # Now get the contribution from the diagonals
         # See wolfram page for generalization of Gell-Mann matrices

--- a/Scripts/symbolic_hermitians/generate_code.py
+++ b/Scripts/symbolic_hermitians/generate_code.py
@@ -268,7 +268,7 @@ if __name__ == "__main__":
     # spherically symmetric part
     N    = HermitianMatrix(args.N, "fab(i\,j\,k\,GIdx::N{}{}_{})")
     Nbar = HermitianMatrix(args.N, "fab(i\,j\,k\,GIdx::N{}{}_{}bar)")
-    HSI  = (N-Nbar) / cell_volume
+    HSI  = (N-Nbar.conjugate()) / cell_volume
     HSI.H[0,0] += rho*Ye/mp
     HSI *= sqrt2GF
     length2 = HSI.SU_vector_magnitude2()

--- a/Scripts/symbolic_hermitians/generate_code.py
+++ b/Scripts/symbolic_hermitians/generate_code.py
@@ -233,7 +233,7 @@ if __name__ == "__main__":
     massmatrix_massbasis = HermitianMatrix(args.N, "M2massbasis{}{}_{}")
     massmatrix_massbasis.H = M2_massbasis
     M2length = massmatrix_massbasis.SU_vector_magnitude()
-    code.append("this->Vvac_max = "+sympy.cxxcode(sympy.simplify(M2length))+"/pupt_min;")
+    code.append("this->Vvac_max = "+sympy.cxxcode(sympy.simplify(M2length))+"*PhysConst::c4/pupt_min;")
     write_code(code, os.path.join(args.emu_home,"Source/generated_files","FlavoredNeutrinoContainerInit.cpp_Vvac_fill"))
     
     #======================#

--- a/Scripts/symbolic_hermitians/generate_code.py
+++ b/Scripts/symbolic_hermitians/generate_code.py
@@ -254,16 +254,23 @@ if __name__ == "__main__":
     Ye = sympy.symbols("fab(i\,j\,k\,GIdx\:\:Ye)",real=True)
     mp = sympy.symbols("PhysConst\:\:Mp",real=True)
     sqrt2GF = sympy.symbols("M_SQRT2*PhysConst\:\:GF",real=True)
-    
+
+    # spherically symmetric part
     N    = HermitianMatrix(args.N, "fab(i\,j\,k\,GIdx::N{}{}_{})")
     Nbar = HermitianMatrix(args.N, "fab(i\,j\,k\,GIdx::N{}{}_{}bar)")
     HSI  = (N-Nbar) / cell_volume
     HSI.H[0,0] += rho*Ye/mp
     HSI *= sqrt2GF
-    
-    length, asdf = HSI.SU_vector_magnitude().as_real_imag()
-    code.append("length = "+sympy.cxxcode(sympy.simplify(length))+";")
+    length2 = HSI.SU_vector_magnitude2()
+    code.append("length2 += "+sympy.cxxcode(sympy.simplify(length2))+";")
 
+    # flux part
+    for component in ["x","y","z"]:
+        F    = HermitianMatrix(args.N, "fab(i\,j\,k\,GIdx::F"+component+"{}{}_{})")
+        Fbar = HermitianMatrix(args.N, "fab(i\,j\,k\,GIdx::F"+component+"{}{}_{}bar)")
+        HSI  = (F-Fbar) * sqrt2GF / cell_volume
+        length2 = HSI.SU_vector_magnitude2()
+        code.append("length2 += "+sympy.cxxcode(sympy.simplify(length2))+";")
     
     write_code(code, os.path.join(args.emu_home,"Source/generated_files","Evolve.cpp_compute_dt_fill"))
 

--- a/Scripts/symbolic_hermitians/generate_code.py
+++ b/Scripts/symbolic_hermitians/generate_code.py
@@ -216,16 +216,26 @@ if __name__ == "__main__":
         U = U23*U13*U12*P
 
     # create M2 matrix in Evolve.H
-    M2 = sympy.zeros(args.N,args.N)
+    M2_massbasis = sympy.zeros(args.N,args.N)
     for i in range(args.N):
-        M2[i,i] = sympy.symbols('parms->mass'+str(i+1),real=True)**2
-    M2 = U*M2*Dagger(U)
+        M2_massbasis[i,i] = sympy.symbols('parms->mass'+str(i+1),real=True)**2
+    M2 = U*M2_massbasis*Dagger(U)
     massmatrix = HermitianMatrix(args.N, "M2matrix{}{}_{}")
     massmatrix.H = M2
     code = massmatrix.code()
     code = ["double "+code[i] for i in range(len(code))]
     write_code(code, os.path.join(args.emu_home, "Source/generated_files","Evolve.H_M2_fill"))
 
+    #=============================================#
+    # FlavoredNeutrinoContainerInit.cpp_Vvac_fill #
+    #=============================================#
+    code = []
+    massmatrix_massbasis = HermitianMatrix(args.N, "M2massbasis{}{}_{}")
+    massmatrix_massbasis.H = M2_massbasis
+    M2length = massmatrix_massbasis.SU_vector_magnitude()
+    code.append("this->Vvac_max = "+sympy.cxxcode(sympy.simplify(M2length))+"/pupt_min;")
+    write_code(code, os.path.join(args.emu_home,"Source/generated_files","FlavoredNeutrinoContainerInit.cpp_Vvac_fill"))
+    
     #======================#
     # Evolve.cpp_Vvac_fill #
     #======================#

--- a/Scripts/symbolic_hermitians/generate_code.py
+++ b/Scripts/symbolic_hermitians/generate_code.py
@@ -233,7 +233,7 @@ if __name__ == "__main__":
     massmatrix_massbasis = HermitianMatrix(args.N, "M2massbasis{}{}_{}")
     massmatrix_massbasis.H = M2_massbasis
     M2length = massmatrix_massbasis.SU_vector_magnitude()
-    code.append("this->Vvac_max = "+sympy.cxxcode(sympy.simplify(M2length))+"*PhysConst::c4/pupt_min;")
+    code.append("Vvac_max = "+sympy.cxxcode(sympy.simplify(M2length))+"*PhysConst::c4/pupt_min;")
     write_code(code, os.path.join(args.emu_home,"Source/generated_files","FlavoredNeutrinoContainerInit.cpp_Vvac_fill"))
     
     #======================#

--- a/Source/Evolve.H
+++ b/Source/Evolve.H
@@ -16,7 +16,7 @@ namespace GIdx
   //    with units of number density. Could add total number density later
   //    too, but this helps with subtractive cancellation errors
     enum {
-        rho, T, Ye, requested_dt, // g/ccm, MeV, unitless
+        rho, T, Ye, // g/ccm, MeV, unitless
         #include "generated_files/Evolve.H_fill"
         ncomp
     };

--- a/Source/Evolve.H
+++ b/Source/Evolve.H
@@ -26,7 +26,7 @@ namespace GIdx
     void Initialize();
 };
 
-amrex::Real compute_dt(const amrex::Geometry& geom, const amrex::Real cfl_factor, const MultiFab& state, const FlavoredNeutrinoContainer& neutrinos, const Real flavor_cfl_factor);
+amrex::Real compute_dt(const amrex::Geometry& geom, const amrex::Real cfl_factor, const MultiFab& state, const FlavoredNeutrinoContainer& neutrinos, const Real flavor_cfl_factor, const Real max_adaptive_speedup);
 
 void deposit_to_mesh(const FlavoredNeutrinoContainer& neutrinos, amrex::MultiFab& state, const amrex::Geometry& geom);
 

--- a/Source/Evolve.H
+++ b/Source/Evolve.H
@@ -26,7 +26,7 @@ namespace GIdx
     void Initialize();
 };
 
-amrex::Real compute_dt(const amrex::Geometry& geom, const amrex::Real cfl_factor, const MultiFab& state, const Real flavor_cfl_factor);
+amrex::Real compute_dt(const amrex::Geometry& geom, const amrex::Real cfl_factor, const MultiFab& state, const FlavoredNeutrinoContainer& neutrinos, const Real flavor_cfl_factor);
 
 void deposit_to_mesh(const FlavoredNeutrinoContainer& neutrinos, amrex::MultiFab& state, const amrex::Geometry& geom);
 

--- a/Source/Evolve.H
+++ b/Source/Evolve.H
@@ -16,7 +16,7 @@ namespace GIdx
   //    with units of number density. Could add total number density later
   //    too, but this helps with subtractive cancellation errors
     enum {
-        rho, T, Ye, // g/ccm, MeV, unitless
+        rho, T, Ye, requested_dt, // g/ccm, MeV, unitless
         #include "generated_files/Evolve.H_fill"
         ncomp
     };

--- a/Source/Evolve.cpp
+++ b/Source/Evolve.cpp
@@ -15,6 +15,7 @@ namespace GIdx
         names.push_back("rho");
         names.push_back("T");
         names.push_back("Ye");
+        names.push_back("requested_dt");
         #include "generated_files/Evolve.cpp_grid_names_fill"
     }
 }

--- a/Source/Evolve.cpp
+++ b/Source/Evolve.cpp
@@ -48,9 +48,9 @@ Real compute_dt(const Geometry& geom, const Real cfl_factor, const MultiFab& sta
             reduce_op.eval(bx, reduce_data,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
             {
-	        Real length = 0;
+	        Real length2 = 0;
                 #include "generated_files/Evolve.cpp_compute_dt_fill"
-                return length;
+                return sqrt(length2);
             });
 	}
 

--- a/Source/Evolve.cpp
+++ b/Source/Evolve.cpp
@@ -57,8 +57,8 @@ Real compute_dt(const Geometry& geom, const Real cfl_factor, const MultiFab& sta
 
 	// extract the reduced values from the combined reduced data structure
 	auto rv = reduce_data.value();
-	Real Vmax_adaptive = amrex::get<0>(rv) + neutrinos.Vvac_max;
-	Real Vmax_stupid   = amrex::get<1>(rv) + neutrinos.Vvac_max;
+	Real Vmax_adaptive = amrex::get<0>(rv) + FlavoredNeutrinoContainer::Vvac_max;
+	Real Vmax_stupid   = amrex::get<1>(rv) + FlavoredNeutrinoContainer::Vvac_max;
 
 	// reduce across MPI ranks
 	ParallelDescriptor::ReduceRealMax(Vmax_adaptive);

--- a/Source/FlavoredNeutrinoContainer.H
+++ b/Source/FlavoredNeutrinoContainer.H
@@ -96,6 +96,11 @@ public:
         return attribute_names;
     }
 
+    void copyParticles(const FlavoredNeutrinoContainer& other, bool local=false){
+        amrex::ParticleContainer<PIdx::nattribs, 0, 0, 0>::copyParticles(other, local);
+        this->Vvac_max = other.Vvac_max;
+    }
+
     /* Public data members */
     static ApplyFlavoredNeutrinoRHS<ParticleType> particle_apply_rhs;
 };

--- a/Source/FlavoredNeutrinoContainer.H
+++ b/Source/FlavoredNeutrinoContainer.H
@@ -68,6 +68,8 @@ class FlavoredNeutrinoContainer
 
 public:
 
+    Real Vvac_max;
+
     FlavoredNeutrinoContainer(const amrex::Geometry            & a_geom,
                               const amrex::DistributionMapping & a_dmap,
                               const amrex::BoxArray            & a_ba);

--- a/Source/FlavoredNeutrinoContainer.H
+++ b/Source/FlavoredNeutrinoContainer.H
@@ -68,7 +68,7 @@ class FlavoredNeutrinoContainer
 
 public:
 
-    Real Vvac_max;
+    inline static Real Vvac_max;
 
     FlavoredNeutrinoContainer(const amrex::Geometry            & a_geom,
                               const amrex::DistributionMapping & a_dmap,
@@ -94,11 +94,6 @@ public:
     amrex::Vector<std::string> get_attribute_names() const
     {
         return attribute_names;
-    }
-
-    void copyParticles(const FlavoredNeutrinoContainer& other, bool local=false){
-        amrex::ParticleContainer<PIdx::nattribs, 0, 0, 0>::copyParticles(other, local);
-        this->Vvac_max = other.Vvac_max;
     }
 
     /* Public data members */

--- a/Source/FlavoredNeutrinoContainerInit.cpp
+++ b/Source/FlavoredNeutrinoContainerInit.cpp
@@ -450,4 +450,9 @@ InitParticles(const TestParams* parms)
         }
         });
     }
+
+    // get the minimum neutrino energy for calculating the timestep
+    Real pupt_min = amrex::ReduceMin(*this, [=] AMREX_GPU_DEVICE (const FlavoredNeutrinoContainer::ParticleType& p) -> Real { return p.rdata(PIdx::pupt); });
+    ParallelDescriptor::ReduceRealMin(pupt_min);
+    #include "generated_files/FlavoredNeutrinoContainerInit.cpp_Vvac_fill"
 }

--- a/Source/Parameters.H
+++ b/Source/Parameters.H
@@ -22,6 +22,7 @@ struct TestParams : public amrex::Gpu::Managed
     Real rho_in, Ye_in, T_in; // g/ccm, 1, MeV
     int simulation_type;
     Real cfl_factor, flavor_cfl_factor;
+    Real max_adaptive_speedup;
     bool do_restart;
     std::string restart_dir;
     Real maxError;
@@ -58,6 +59,7 @@ struct TestParams : public amrex::Gpu::Managed
         pp.get("T_MeV", T_in);
         pp.get("cfl_factor", cfl_factor);
         pp.get("flavor_cfl_factor", flavor_cfl_factor);
+        pp.get("max_adaptive_speedup", max_adaptive_speedup);
         pp.get("write_plot_every", write_plot_every);
         pp.get("write_plot_particles_every", write_plot_particles_every);
         pp.get("do_restart", do_restart);

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -194,7 +194,7 @@ void evolve_flavor(const TestParams* parms)
         // Note: this won't be the same as the new-time grid data
         // because the last deposit_to_mesh call was at either the old time (forward Euler)
         // or the final RK stage, if using Runge-Kutta.
-        const Real dt = compute_dt(geom,parms->cfl_factor,state,parms->flavor_cfl_factor);
+        const Real dt = compute_dt(geom,parms->cfl_factor,state,neutrinos,parms->flavor_cfl_factor);
         integrator.set_timestep(dt);
     };
 
@@ -203,7 +203,7 @@ void evolve_flavor(const TestParams* parms)
     integrator.set_post_timestep(post_timestep_fun);
 
     // Get a starting timestep
-    const Real starting_dt = compute_dt(geom,parms->cfl_factor,state,parms->flavor_cfl_factor);
+    const Real starting_dt = compute_dt(geom,parms->cfl_factor,state,neutrinos_old,parms->flavor_cfl_factor);
 
     // Do all the science!
     amrex::Print() << "Starting timestepping loop... " << std::endl;

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -194,7 +194,7 @@ void evolve_flavor(const TestParams* parms)
         // Note: this won't be the same as the new-time grid data
         // because the last deposit_to_mesh call was at either the old time (forward Euler)
         // or the final RK stage, if using Runge-Kutta.
-        const Real dt = compute_dt(geom,parms->cfl_factor,state,neutrinos,parms->flavor_cfl_factor);
+        const Real dt = compute_dt(geom,parms->cfl_factor,state,neutrinos,parms->flavor_cfl_factor,parms->max_adaptive_speedup);
         integrator.set_timestep(dt);
     };
 
@@ -203,7 +203,7 @@ void evolve_flavor(const TestParams* parms)
     integrator.set_post_timestep(post_timestep_fun);
 
     // Get a starting timestep
-    const Real starting_dt = compute_dt(geom,parms->cfl_factor,state,neutrinos_old,parms->flavor_cfl_factor);
+    const Real starting_dt = compute_dt(geom,parms->cfl_factor,state,neutrinos_old,parms->flavor_cfl_factor, parms->max_adaptive_speedup);
 
     // Do all the science!
     amrex::Print() << "Starting timestepping loop... " << std::endl;

--- a/sample_inputs/inputs_1d_fiducial
+++ b/sample_inputs/inputs_1d_fiducial
@@ -10,7 +10,8 @@ st4_fluxfacbar = .333333333333333
 st4_amplitude = 1e-6
 
 cfl_factor = 0.5
-flavor_cfl_factor = 0.05
+flavor_cfl_factor = 0.5
+max_adaptive_speedup = 0
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_1d_fiducial
+++ b/sample_inputs/inputs_1d_fiducial
@@ -10,7 +10,7 @@ st4_fluxfacbar = .333333333333333
 st4_amplitude = 1e-6
 
 cfl_factor = 0.5
-flavor_cfl_factor = 0.5
+flavor_cfl_factor = 0.05
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_bipolar_test
+++ b/sample_inputs/inputs_bipolar_test
@@ -1,6 +1,7 @@
 simulation_type = 1
 cfl_factor = 0.5
-flavor_cfl_factor = .1
+max_adaptive_speedup = 0
+flavor_cfl_factor = .5
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_bipolar_test
+++ b/sample_inputs/inputs_bipolar_test
@@ -1,6 +1,6 @@
 simulation_type = 1
 cfl_factor = 0.5
-flavor_cfl_factor = .05
+flavor_cfl_factor = .1
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_bipolar_test
+++ b/sample_inputs/inputs_bipolar_test
@@ -1,6 +1,6 @@
 simulation_type = 1
 cfl_factor = 0.5
-flavor_cfl_factor = .5
+flavor_cfl_factor = .05
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_fast_flavor
+++ b/sample_inputs/inputs_fast_flavor
@@ -1,6 +1,6 @@
 simulation_type = 2
 cfl_factor = 0.5
-flavor_cfl_factor = .5
+flavor_cfl_factor = .05
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_fast_flavor
+++ b/sample_inputs/inputs_fast_flavor
@@ -1,6 +1,6 @@
 simulation_type = 2
 cfl_factor = 0.5
-flavor_cfl_factor = .05
+flavor_cfl_factor = .5
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_fast_flavor
+++ b/sample_inputs/inputs_fast_flavor
@@ -1,6 +1,7 @@
 simulation_type = 2
 cfl_factor = 0.5
 flavor_cfl_factor = .5
+max_adaptive_speedup = 0
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_fast_flavor_nonzerok
+++ b/sample_inputs/inputs_fast_flavor_nonzerok
@@ -3,7 +3,7 @@ st3_amplitude = 1e-6
 st3_wavelength_fraction_of_domain = 1
 
 cfl_factor = 0.5
-flavor_cfl_factor = 0.5
+flavor_cfl_factor = 0.05
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_fast_flavor_nonzerok
+++ b/sample_inputs/inputs_fast_flavor_nonzerok
@@ -3,7 +3,7 @@ st3_amplitude = 1e-6
 st3_wavelength_fraction_of_domain = 1
 
 cfl_factor = 0.5
-flavor_cfl_factor = 0.05
+flavor_cfl_factor = 0.5
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_fast_flavor_nonzerok
+++ b/sample_inputs/inputs_fast_flavor_nonzerok
@@ -4,6 +4,7 @@ st3_wavelength_fraction_of_domain = 1
 
 cfl_factor = 0.5
 flavor_cfl_factor = 0.5
+max_adaptive_speedup = 0
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_msw_test
+++ b/sample_inputs/inputs_msw_test
@@ -1,6 +1,7 @@
 simulation_type = 0
 cfl_factor = 0.5
 flavor_cfl_factor = 0.1
+max_adaptive_speedup = 0
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_msw_test
+++ b/sample_inputs/inputs_msw_test
@@ -1,6 +1,6 @@
 simulation_type = 0
 cfl_factor = 0.5
-flavor_cfl_factor = 0.05
+flavor_cfl_factor = 0.1
 maxError = 1e-6
 
 integration.type = 1

--- a/sample_inputs/inputs_msw_test
+++ b/sample_inputs/inputs_msw_test
@@ -1,6 +1,6 @@
 simulation_type = 0
 cfl_factor = 0.5
-flavor_cfl_factor = 0.1
+flavor_cfl_factor = 0.05
 maxError = 1e-6
 
 integration.type = 1


### PR DESCRIPTION
The timestep now properly takes into account the full potential. The vacuum term is split off from the other terms for two reasons. First, the minimum neutrino energy (and hence maximum vacuum potential) needs only be calculated at the beginning of the simulation because the particle energies don't change. Second, the vacuum and matter/self-interaction potentials combine differently for neutrinos and antineutrinos, so I figured it would be better to just take the more conservative limit and add the magnitudes of those separately rather than do a more complicated grid reduction for neutrinos and antineutrinos separately.

I left in the original way of calculating the timestep as `dt_stupid` (though it is slightly different in that it includes the vacuum contribution). Setting `max_adaptive_speedup` to 0 will force the use of the original timestep. Setting it to 1e99 (or in general towards infinity) will allow the timestep to always be the one as determined by the current potential. This can lead to problems if the potential is zero and the timestep becomes extremely large. This can be a problem in the first step of the bipolar test case, for example. I left `max_adaptive_speedup` as 0 in all of the test parameter files.

Closes #43 