### PR TITLE
Add linting as github Actions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,116 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats: 
+  - Language:        TextProto
+    BasedOnStyle:    google
+ReflowComments:  false
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        4
+UseTab:          Never
+...
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+Scripts/tests -linguist-detectable
+Scripts/visualization -linguist-detectable
+

--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -1,0 +1,39 @@
+name: cpp-linter
+
+on: [pull_request]
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get submodules 
+        run: |
+          git submodule update --init
+
+      - name: Run cpp linter
+        uses: AMReX-Astro/cpp-linter-action@main
+        with: 
+          build_path: 'Exec'
+          make_options: '-j 2 USE_OMP=FALSE USE_MPI=FALSE USE_CUDA=FALSE DIM=3 DEBUG=TRUE'
+          ignore_files: 'amrex'
+          header_filter: 'Emu'
+          checks: 'bugprone-*,performance-*,portability-*,modernize-*,clang-analyzer-*,cppcoreguidelines-*,readability-*,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-bounds-constant-array-index,-clang-diagnostic-unknown-warning-option,-clang-diagnostic-unknown-pragmas,-readability-avoid-const-params-in-decls,-cppcoreguidelines-owning-memory'
+      
+      - name: Archive clang tidy report
+        uses: actions/upload-artifact@v1
+        with:
+          name: clang-tidy-report
+          path: clang-tidy-report.txt
+      
+    #   - name: Archive clang format report
+    #     uses: actions/upload-artifact@v1
+    #     with:
+    #       name: clang-format-report
+    #       path: clang-format-report.txt
+      
+      - name: Archive cppcheck report
+        uses: actions/upload-artifact@v1
+        with:
+          name: cppcheck-report
+          path: cppcheck-report.txt

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,37 @@
+name: Clang-format
+
+on:
+  pull_request:
+    branches: development
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        ref: refs/heads/${{ github.head_ref }}
+
+    - name: Run tab exterminator script
+      run: |
+        cd Scripts/util
+        ./tab_exterminator.sh
+
+    - name: Run clang-format
+      run: |
+        find . -regex '.*\.\(cpp\|h\|H\)' | xargs clang-format -i -style=file
+
+    - name: Commit files
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add --all
+        git diff-index --quiet HEAD || git commit -m "Clang-format has tidied up the code."
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      if: github.repository_owner == 'AMReX-Astro' 
+      with:
+        branch: ${{ github.head_ref }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Scripts/util/tab_exterminator.sh
+++ b/Scripts/util/tab_exterminator.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for f in $(grep -rIPl "\t" ../../Source)
+do
+	echo "Converting tabs to spaces in $f"
+	expand -t 8 $f > tmp_file
+	mv tmp_file $f
+done

--- a/Scripts/util/tab_exterminator.sh
+++ b/Scripts/util/tab_exterminator.sh
@@ -2,6 +2,6 @@
 for f in $(grep -rIPl "\t" ../../Source)
 do
 	echo "Converting tabs to spaces in $f"
-	expand -t 8 $f > tmp_file
+	expand -t 4 $f > tmp_file
 	mv tmp_file $f
 done


### PR DESCRIPTION
Uses `clang-tidy` and `clang-format` along with the tab extermination script.

All originally implemented in https://github.com/AMReX-Astro/MAESTROeX by @harpolea and kindly donated to Emu.

