### PR TITLE
Clang format 2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,116 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats: 
+  - Language:        TextProto
+    BasedOnStyle:    google
+ReflowComments:  false
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        4
+UseTab:          Never
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,6 @@
+# clang-tidy configuration for Emu's C++ static analysis (used by the cpp-linter CI).
+# clang-tidy auto-discovers this file from each source file's parent directories, so
+# it applies to everything under Source/. These checks were previously passed via the
+# cpp-linter-action 'checks:' input, which the action no longer supports.
+---
+Checks: 'bugprone-*,performance-*,portability-*,modernize-*,clang-analyzer-*,cppcoreguidelines-*,readability-*,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-bounds-constant-array-index,-clang-diagnostic-unknown-warning-option,-clang-diagnostic-unknown-pragmas,-readability-avoid-const-params-in-decls,-cppcoreguidelines-owning-memory'

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+Scripts/tests -linguist-detectable
+Scripts/visualization -linguist-detectable
+

--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -27,7 +27,14 @@ jobs:
       - name: Install build and analysis tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang clang-tidy cppcheck bear g++ gfortran make
+          sudo apt-get install -y clang clang-tidy cppcheck bear g++ gfortran make \
+                                  libhdf5-dev zlib1g-dev
+          # Ubuntu installs HDF5 under a split "serial" layout. AMReX's makefile
+          # expects a single prefix with include/ and lib/ subdirectories, so
+          # assemble one out of symlinks for HDF5_HOME to point at.
+          sudo mkdir -p /opt/hdf5
+          sudo ln -sf /usr/include/hdf5/serial            /opt/hdf5/include
+          sudo ln -sf /usr/lib/x86_64-linux-gnu/hdf5/serial /opt/hdf5/lib
 
       - name: Cache pip downloads
         uses: actions/cache@v4
@@ -43,7 +50,7 @@ jobs:
           set -euo pipefail
           cp makefiles/GNUmakefile_default Exec/GNUmakefile
           cd Exec
-          bear -- make -j2 USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE USE_HDF5=FALSE DEBUG=TRUE
+          bear -- make -j2 USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE USE_HDF5=TRUE HDF5_HOME=/opt/hdf5 DEBUG=TRUE
 
       - name: Run clang-tidy
         continue-on-error: true

--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -1,0 +1,81 @@
+name: cpp-linter
+
+# Runs clang-tidy and cppcheck on Emu's C++ and uploads the reports as artifacts.
+# Findings are advisory. Runs on every push to a branch and on every pull request.
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+# Cancel an in-progress run when newer commits arrive on the same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check out the AMReX submodule
+        run: git submodule update --init submodules/amrex
+
+      - name: Install build and analysis tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang clang-tidy cppcheck bear g++ gfortran make
+
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-sympy-${{ runner.os }}
+
+      - name: Install sympy
+        run: pip3 install --user sympy
+
+      - name: Build and capture the compilation database
+        run: |
+          set -euo pipefail
+          cp makefiles/GNUmakefile_default Exec/GNUmakefile
+          cd Exec
+          bear -- make -j2 USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE USE_HDF5=FALSE DEBUG=TRUE
+
+      - name: Run clang-tidy
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          clang-tidy --version
+          # Checks come from the repo-root .clang-tidy; header-filter limits diagnostics
+          # to Emu's own headers (amrex under submodules/ is excluded).
+          find Source -name '*.cpp' -not -path 'Source/generated_files/*' -print0 \
+            | xargs -0 clang-tidy -p Exec -header-filter='Source/' | tee clang-tidy-report.txt
+
+      - name: Run cppcheck
+        continue-on-error: true
+        run: |
+          cppcheck --enable=warning,performance,portability --std=c++20 --language=c++ \
+                   --project=Exec/compile_commands.json \
+                   --file-filter='*Source*' \
+                   --suppress=missingInclude --suppress=missingIncludeSystem \
+                   2> cppcheck-report.txt
+
+      - name: Archive clang-tidy report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-report
+          path: clang-tidy-report.txt
+          if-no-files-found: ignore
+
+      - name: Archive cppcheck report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cppcheck-report
+          path: cppcheck-report.txt
+          if-no-files-found: ignore

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,57 @@
+name: Clang-format
+
+# Auto-formats hand-written C++ and pushes the result back to the branch. Runs on
+# every push to a branch and on every pull request, so individual development
+# branches are tidied, not just PRs into development.
+
+on:
+  push:
+  pull_request:
+
+# Needed for the bot to push the formatting commit back to the branch.
+permissions:
+  contents: write
+
+# Don't let two runs on the same branch race to push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        # Check out the real branch (the PR source branch on pull_request, the pushed
+        # branch on push) with attached HEAD so we can commit and push fixes back.
+        ref: ${{ github.head_ref || github.ref_name }}
+
+    - name: Run tab exterminator script
+      run: |
+        cd Scripts/util
+        ./tab_exterminator.sh
+
+    - name: Run clang-format
+      run: |
+        find . -regex '.*\.\(cpp\|h\|H\)' | xargs clang-format -i -style=file
+
+    # Advisory: print what clang-format would change. continue-on-error=true keeps the
+    # check green even when formatting differences exist.
+    - name: Show formatting diff
+      continue-on-error: false
+      run: git diff --exit-code
+
+    # - name: Commit files
+    #   run: |
+    #     git config --local user.email "action@github.com"
+    #     git config --local user.name "GitHub Action"
+    #     git add --all
+    #     git diff-index --quiet HEAD || git commit -m "Clang-format has tidied up the code."
+
+    # # Pushes made with the built-in GITHUB_TOKEN do not retrigger workflows, so this
+    # # cannot loop. Restricted to the main repo (forks get a read-only token).
+    # - name: Push changes
+    #   if: github.repository_owner == 'AMReX-Astro'
+    #   run: git push origin HEAD:${{ github.head_ref || github.ref_name }}

--- a/Scripts/util/tab_exterminator.sh
+++ b/Scripts/util/tab_exterminator.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for f in $(grep -rIPl "\t" ../../Source)
+do
+	echo "Converting tabs to spaces in $f"
+	expand -t 4 $f > tmp_file
+	mv tmp_file $f
+done


### PR DESCRIPTION
changed the linting to be advisory. Checks fail if formatting is not compliant, but it does not automatically make formatting commits.